### PR TITLE
Fix typing error on transactionProps

### DIFF
--- a/src/components/transaction-card.tsx
+++ b/src/components/transaction-card.tsx
@@ -30,7 +30,7 @@ interface TransactionProps {
     currency: string;
     date: string;
     location: string;
-    imageUrl: string;
+    imageUrl?: string;
   };
 }
 


### PR DESCRIPTION
Fix typing error on props, make url optional